### PR TITLE
Treat different coordinate systems in IDF correctly

### DIFF
--- a/coordinatetransformer.py
+++ b/coordinatetransformer.py
@@ -3,20 +3,46 @@ import math3d as m3d
 
 
 class CoordinateTransformer:
+    """
+    Transform between IDF and NeXus, units and coordinates
+    """
     def __init__(self, angles_in_degrees=True, nexus_coords=None):
+        self.angles_in_degrees = angles_in_degrees
         if nexus_coords is None:
             nexus_coords = ['x', 'y', 'z']
+        self.default_coords = (nexus_coords == ['x', 'y', 'z'])
+        self.nexus_coords_signs = \
+            np.array([-1.0 if self.__is_negative(axis) else 1.0 for axis in nexus_coords]).astype(float)
+        unsigned_nexus_coords = [coord[1:] if self.__is_negative(coord) else coord for coord in nexus_coords]
+        self.nexus_coords_order = np.array([unsigned_nexus_coords.index('x'), unsigned_nexus_coords.index('y'),
+                                            unsigned_nexus_coords.index('z')])
+
+    def get_angle_in_degrees(self, angle):
+        """
+        Convert angle to degrees if it isn't already
+
+        :param angle: Angle to return in degrees
+        :return: Angle in degrees
+        """
+        return angle if self.angles_in_degrees else np.deg2rad(angle)
+
+    def get_nexus_coordinates(self, vector):
+        """
+        Convert vector in the IDF coordinate system to vector in the NeXus coordinate system
+
+        :param vector: Vector in IDF coordinate system
+        :return: Vector as a numpy array in the NeXus coordinate system
+        """
+        vector = np.array(vector)  # Make sure vector is a numpy array
+        if self.default_coords:
+            return vector
+        else:
+            vector = np.multiply(vector, self.nexus_coords_signs)
+            return vector[self.nexus_coords_order]
 
     @staticmethod
-    def math3d_example():
-        # A rotation of 1 radian around the axis (1,2,3)
-        r = m3d.Orientation.new_axis_angle([1, 2, 3], 1)
-        # v = m3d.Vector(4, 5, 6) or as a numpy array like this:
-        v = m3d.Vector(np.array([4, 5, 6]))
-        # Apply rotation to vector v
-        result = r * v
-        # Convert result to a numpy array
-        print(result.get_array())
+    def __is_negative(direction):
+        return direction[0] == '-'
 
     @staticmethod
     def spherical_to_cartesian(rthetaphi):
@@ -39,3 +65,14 @@ class CoordinateTransformer:
         theta = np.arccos(z / r) * 180 / np.pi  # to degrees
         phi = np.arctan2(y, x) * 180 / np.pi
         return [r, theta, phi]
+
+    @staticmethod
+    def math3d_example():
+        # A rotation of 1 radian around the axis (1,2,3)
+        r = m3d.Orientation.new_axis_angle([1, 2, 3], 1)
+        # v = m3d.Vector(4, 5, 6) or as a numpy array like this:
+        v = m3d.Vector(np.array([4, 5, 6]))
+        # Apply rotation to vector v
+        result = r * v
+        # Convert result to a numpy array
+        print(result.get_array())

--- a/coordinatetransformer.py
+++ b/coordinatetransformer.py
@@ -1,0 +1,41 @@
+import numpy as np
+import math3d as m3d
+
+
+class CoordinateTransformer:
+    def __init__(self, angles_in_degrees=True, nexus_coords=None):
+        if nexus_coords is None:
+            nexus_coords = ['x', 'y', 'z']
+
+    @staticmethod
+    def math3d_example():
+        # A rotation of 1 radian around the axis (1,2,3)
+        r = m3d.Orientation.new_axis_angle([1, 2, 3], 1)
+        # v = m3d.Vector(4, 5, 6) or as a numpy array like this:
+        v = m3d.Vector(np.array([4, 5, 6]))
+        # Apply rotation to vector v
+        result = r * v
+        # Convert result to a numpy array
+        print(result.get_array())
+
+    @staticmethod
+    def spherical_to_cartesian(rthetaphi):
+        # takes list rthetaphi (single coordinate)
+        r = rthetaphi[0]
+        theta = rthetaphi[1] * np.pi / 180  # to radian
+        phi = rthetaphi[2] * np.pi / 180
+        x = r * np.sin(theta) * np.cos(phi)
+        y = r * np.sin(theta) * np.sin(phi)
+        z = r * np.cos(theta)
+        return [x, y, z]
+
+    @staticmethod
+    def cartesian_to_spherical(xyz):
+        # takes list xyz (single coordinate)
+        x = xyz[0]
+        y = xyz[1]
+        z = xyz[2]
+        r = np.sqrt(x * x + y * y + z * z)
+        theta = np.arccos(z / r) * 180 / np.pi  # to degrees
+        phi = np.arctan2(y, x) * 180 / np.pi
+        return [r, theta, phi]

--- a/idfparser.py
+++ b/idfparser.py
@@ -356,7 +356,6 @@ class IDFParser:
         if xml_along_beam is None or xml_up is None:
             raise Exception('Expected "along-beam" and "pointing-up" to be specified '
                             'in the default reference frame in the IDF')
-        nexus_x = None
         nexus_y = xml_up.get('axis')
         nexus_z = xml_along_beam.get('axis')
         handedness = 'right'

--- a/idfparser.py
+++ b/idfparser.py
@@ -353,7 +353,7 @@ class IDFParser:
         xml_ref_frame = xml_defaults.find('d:reference-frame', self.ns)
         xml_along_beam = xml_ref_frame.find('d:along-beam', self.ns)
         xml_up = xml_ref_frame.find('d:pointing-up', self.ns)
-        if not xml_along_beam or not xml_up:
+        if xml_along_beam is None or xml_up is None:
             raise Exception('Expected "along-beam" and "pointing-up" to be specified '
                             'in the default reference frame in the IDF')
         nexus_x = None
@@ -374,18 +374,20 @@ class IDFParser:
                             nexus_z[1:] if is_negative(nexus_z) else nexus_z]
 
         # Assuming right-handedness
-        if unsigned_yz_list is ['y', 'z']:
+        if unsigned_yz_list == ['y', 'z']:
             nexus_x = 'x'
-        elif unsigned_yz_list is ['z', 'y']:
+        elif unsigned_yz_list == ['z', 'y']:
             nexus_x = '-x'
-        elif unsigned_yz_list is ['x', 'y']:
+        elif unsigned_yz_list == ['x', 'y']:
             nexus_x = '-z'
-        elif unsigned_yz_list is ['y', 'x']:
+        elif unsigned_yz_list == ['y', 'x']:
             nexus_x = 'z'
-        elif unsigned_yz_list is ['x', 'z']:
+        elif unsigned_yz_list == ['x', 'z']:
             nexus_x = 'y'
-        elif unsigned_yz_list is ['z', 'x']:
+        elif unsigned_yz_list == ['z', 'x']:
             nexus_x = '-y'
+        else:
+            raise RuntimeError('Unexpected yz list in IDFParser.__get_default_coord_systems')
 
         if is_negative(nexus_y) ^ is_negative(nexus_z):
             nexus_x = flip_axis(nexus_x)

--- a/idfparser.py
+++ b/idfparser.py
@@ -79,9 +79,24 @@ class IDFParser:
                         yield det_bank_info
 
     def __get_vector(self, xml_point):
-        return np.array([self.__none_to_zero(xml_point.get('x')),
-                         self.__none_to_zero(xml_point.get('y')),
-                         self.__none_to_zero(xml_point.get('z'))]).astype(float)
+        x = xml_point.get('x')
+        y = xml_point.get('y')
+        z = xml_point.get('z')
+        if [x, y, z] == [None, None, None]:
+            # No cartesian axes, maybe there are spherical?
+            r = xml_point.get('r')
+            t = xml_point.get('t')
+            p = xml_point.get('p')
+            vector = np.array([self.__none_to_zero(r),
+                               self.__none_to_zero(t),
+                               self.__none_to_zero(p)]).astype(float)
+            vector = self.transform.spherical_to_cartesian(vector)
+        else:
+            vector = np.array([self.__none_to_zero(x),
+                               self.__none_to_zero(y),
+                               self.__none_to_zero(z)]).astype(float)
+
+        return self.transform.get_nexus_coordinates(vector)
 
     def __get_pixel_names_and_shapes(self):
         pixels = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ packaging==16.8
 pyparsing==2.2.0
 six==1.10.0
 tables==3.4.2
+math3d==3.1.3


### PR DESCRIPTION
Fixes #1 
Fixes #4 

Now handles spherical coordinates in IDF by converting to cartesian. Transformations are carried out when the coordinate system defined in the IDF differs from the NeXus standard one.